### PR TITLE
Don't use amz headers in signing process if they aren't present

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.1.7
+==================
+* Don't use amz headers for signature calculation if they aren't
+  present.
+
 0.1.6 (2021-09-01)
 ==================
 * Add webp, svg, and pdf mime types.

--- a/s3sign/views.py
+++ b/s3sign/views.py
@@ -111,8 +111,13 @@ class SignS3View(View):
 
         expires = int(self.now_time() + self.get_expiration_time())
 
-        put_request = "PUT\n\n%s\n%d\n%s\n/%s/%s" % (
-            mime_type, expires, self.get_amz_headers(), S3_BUCKET, object_name)
+        if self.get_amz_headers():
+            put_request = "PUT\n\n%s\n%d\n%s\n/%s/%s" % (
+                mime_type, expires, self.get_amz_headers(),
+                S3_BUCKET, object_name)
+        else:
+            put_request = "PUT\n\n%s\n%d\n/%s/%s" % (
+                mime_type, expires, S3_BUCKET, object_name)
 
         signature = base64.encodebytes(
             hmac.new(


### PR DESCRIPTION
This fixes a "Signature does not match" upload error when uploading
private media.