### PR TITLE
Fix signed signature bug

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.1.9
+==================
+* Fix bug where signatures with '+' in weren't being properly encoded.
+
 0.1.8 (2021-09-02)
 ==================
 * Add `SignS3View.private` flag to determine whether we're uploading

--- a/s3sign/views.py
+++ b/s3sign/views.py
@@ -191,8 +191,9 @@ class SignS3View(View):
         }
 
         if self.private:
-            data['signed_get_url'] = self.create_presigned_url(
-                S3_BUCKET, object_name, self.get_expiration_time()),
+            data['signed_get_url'] = quote(
+                self.create_presigned_url(
+                    S3_BUCKET, object_name, self.get_expiration_time()))
 
         return HttpResponse(
             json.dumps(data), content_type='application/json')


### PR DESCRIPTION
The signed URL needs to be encoded with quote() so it can be properly
used in javascript.