### PR TITLE
Move s3 signing functions out of views.py

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.2.1
+==================
+* Move s3 signing functions out of the view so they can be imported
+  and used separately.
+
 0.2.0 (2021-09-08)
 ==================
 * This library now requires boto3 and botocore to be installed.

--- a/s3sign/utils.py
+++ b/s3sign/utils.py
@@ -1,0 +1,74 @@
+import logging
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+
+s3_config = Config(
+    signature_version='s3v4',
+    s3={'addressing_style': 'path'},
+)
+
+
+def create_presigned_url(s3_client, bucket_name, object_name, expiration=3600):
+    """Generate a presigned URL to share an S3 object
+
+    From: https://boto3.amazonaws.com/v1/documentation/api/latest/
+                             guide/s3-presigned-urls.html
+
+    :param bucket_name: string
+    :param object_name: string
+    :param expiration: Time in seconds for the presigned URL to
+      remain valid
+    :return: Presigned URL as string. If error, returns None.
+    """
+
+    # Generate a presigned URL for the S3 object
+    try:
+        response = s3_client.generate_presigned_url(
+            'get_object',
+            Params={'Bucket': bucket_name,
+                    'Key': object_name},
+            ExpiresIn=expiration)
+    except ClientError as e:
+        logging.error(e)
+        return None
+
+    # The response contains the presigned URL
+    return response
+
+
+def create_presigned_url_expanded(
+        s3_client, client_method_name, method_parameters=None,
+        expiration=3600, http_method=None):
+    """Generate a presigned URL to invoke an S3.Client method
+
+    Not all the client methods provided in the AWS Python SDK are
+    supported.
+
+    :param client_method_name: Name of the S3.Client method, e.g.,
+    'list_buckets'
+
+    :param method_parameters: Dictionary of parameters to send to
+    the method
+
+    :param expiration: Time in seconds for the presigned URL to
+    remain valid
+
+    :param http_method: HTTP method to use (GET, etc.)
+    :return: Presigned URL as string. If error, returns None.
+    """
+
+    # Generate a presigned URL for the S3 client method
+
+    try:
+        response = s3_client.generate_presigned_url(
+            ClientMethod=client_method_name,
+            Params=method_parameters,
+            ExpiresIn=expiration,
+            HttpMethod=http_method)
+    except ClientError as e:
+        logging.error(e)
+        return None
+
+    # The response contains the presigned URL
+    return response

--- a/s3sign/views.py
+++ b/s3sign/views.py
@@ -4,10 +4,7 @@ import json
 import time
 import uuid
 
-import logging
 import boto3
-from botocore.config import Config
-from botocore.exceptions import ClientError
 
 from datetime import datetime
 
@@ -15,10 +12,8 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.views.generic import View
 
-
-s3_config = Config(
-    signature_version='s3v4',
-    s3={'addressing_style': 'path'},
+from s3sign.utils import (
+    s3_config, create_presigned_url, create_presigned_url_expanded
 )
 
 
@@ -112,70 +107,6 @@ class SignS3View(View):
             now=now, basename=basename, extension=extension,
             root=self.get_root())
 
-    def create_presigned_url(self, bucket_name, object_name,
-                             expiration=3600):
-        """Generate a presigned URL to share an S3 object
-
-        From: https://boto3.amazonaws.com/v1/documentation/api/latest/
-                                 guide/s3-presigned-urls.html
-
-        :param bucket_name: string
-        :param object_name: string
-        :param expiration: Time in seconds for the presigned URL to
-          remain valid
-        :return: Presigned URL as string. If error, returns None.
-        """
-
-        # Generate a presigned URL for the S3 object
-        try:
-            response = self.s3_client.generate_presigned_url(
-                'get_object',
-                Params={'Bucket': bucket_name,
-                        'Key': object_name},
-                ExpiresIn=expiration)
-        except ClientError as e:
-            logging.error(e)
-            return None
-
-        # The response contains the presigned URL
-        return response
-
-    def create_presigned_url_expanded(
-            self, client_method_name, method_parameters=None,
-            expiration=3600, http_method=None):
-        """Generate a presigned URL to invoke an S3.Client method
-
-        Not all the client methods provided in the AWS Python SDK are
-        supported.
-
-        :param client_method_name: Name of the S3.Client method, e.g.,
-        'list_buckets'
-
-        :param method_parameters: Dictionary of parameters to send to
-        the method
-
-        :param expiration: Time in seconds for the presigned URL to
-        remain valid
-
-        :param http_method: HTTP method to use (GET, etc.)
-        :return: Presigned URL as string. If error, returns None.
-        """
-
-        # Generate a presigned URL for the S3 client method
-
-        try:
-            response = self.s3_client.generate_presigned_url(
-                ClientMethod=client_method_name,
-                Params=method_parameters,
-                ExpiresIn=expiration,
-                HttpMethod=http_method)
-        except ClientError as e:
-            logging.error(e)
-            return None
-
-        # The response contains the presigned URL
-        return response
-
     def get(self, request):
         S3_BUCKET = self.get_bucket()
         mime_type = self.get_mimetype(request)
@@ -200,8 +131,10 @@ class SignS3View(View):
         if self.acl:
             put_data['ACL'] = self.acl
 
-        signed_request = self.create_presigned_url_expanded(
-            'put_object', put_data, self.get_expiration_time(), 'PUT')
+        signed_request = create_presigned_url_expanded(
+            self.s3_client, 'put_object', put_data,
+            self.get_expiration_time(), 'PUT'
+        )
 
         data = {
             'signed_request': signed_request,
@@ -209,8 +142,10 @@ class SignS3View(View):
         }
 
         if self.private:
-            data['signed_get_url'] = self.create_presigned_url(
-                S3_BUCKET, object_name, self.get_expiration_time())
+            data['signed_get_url'] = create_presigned_url(
+                self.s3_client, S3_BUCKET,
+                object_name, self.get_expiration_time()
+            )
 
         return HttpResponse(
             json.dumps(data), content_type='application/json')


### PR DESCRIPTION
So I can use them directly from Mediathread without having similar code
in both places.