### PR TITLE
Update expiration time to 8 hours.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.3.1
 ==================
 * Use default max file size of 2gb.
+* Update default expiration time to 8 hours.
 
 0.3.0 (2021-09-15)
 ==================

--- a/s3sign/views.py
+++ b/s3sign/views.py
@@ -20,7 +20,7 @@ from s3sign.utils import (
 class SignS3View(View):
     name_field = 's3_object_name'
     type_field = 's3_object_type'
-    expiration_time = 10
+    expiration_time = 3600 * 8  # 8 hours
     mime_type_extensions = [
         ('bmp', '.bmp'),
         ('gif', '.gif'),


### PR DESCRIPTION
This was originally set to "10" - I'm not sure if that's intended to
mean 10 hours? Anyways, now the format is in seconds, as AWS expects.