### PR TITLE
Use triple instead of double equals

### DIFF
--- a/s3sign/static/s3sign/js/s3upload.js
+++ b/s3sign/static/s3sign/js/s3upload.js
@@ -23,7 +23,7 @@
         };
 
         function S3Upload(options) {
-            if (options == null) options = {};
+            if (options === null) options = {};
             let option;
             for (option in options) {
                 this[option] = options[option];
@@ -54,7 +54,7 @@
             var xhr;
             xhr = new XMLHttpRequest();
 
-            if (xhr.withCredentials != null) {
+            if (xhr.withCredentials !== null) {
                 xhr.open(method, url, true);
             } else if (typeof XDomainRequest !== "undefined") {
                 xhr = new XDomainRequest();


### PR DESCRIPTION
To reduce ambiguity.