### PR TITLE
Rename AWS vars to be inline with other package's needed AWS var names

### DIFF
--- a/s3sign/tests/test_views.py
+++ b/s3sign/tests/test_views.py
@@ -62,17 +62,17 @@ class TestView(TestCase):
         v = SignS3View()
         self.assertIsNotNone(v.get_name_field())
 
-    @override_settings(AWS_ACCESS_KEY='foo')
+    @override_settings(AWS_ACCESS_KEY_ID='foo')
     def test_get_aws_access_key(self):
         v = SignS3View()
         self.assertEqual(v.get_aws_access_key(), 'foo')
 
-    @override_settings(AWS_SECRET_KEY='foo')
+    @override_settings(AWS_SECRET_ACCESS_KEY='foo')
     def test_get_aws_secret_key(self):
         v = SignS3View()
         self.assertEqual(v.get_aws_secret_key(), 'foo')
 
-    @override_settings(AWS_UPLOAD_BUCKET='foo')
+    @override_settings(AWS_STORAGE_BUCKET_NAME='foo')
     def test_get_aws_bucket(self):
         v = SignS3View()
         self.assertEqual(v.get_bucket(), 'foo')

--- a/s3sign/views.py
+++ b/s3sign/views.py
@@ -72,13 +72,13 @@ class SignS3View(View):
         return self.path_string
 
     def get_aws_access_key(self):
-        return settings.AWS_ACCESS_KEY
+        return settings.AWS_ACCESS_KEY_ID
 
     def get_aws_secret_key(self):
-        return settings.AWS_SECRET_KEY
+        return settings.AWS_SECRET_ACCESS_KEY
 
     def get_bucket(self):
-        return settings.AWS_UPLOAD_BUCKET
+        return settings.AWS_STORAGE_BUCKET_NAME
 
     def get_mimetype(self, request):
         return request.GET.get(self.get_type_field())


### PR DESCRIPTION
Consolidating variable names to reduce repeats in django settings file.

These are the same variable names also used by django-storages.