### PR TITLE
Don't call onProgress event if file list is empty

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.3.2
+==================
+* Don't call onProgress event handler if file list is empty.
+
 0.3.1 (2022-02-17)
 ==================
 * Use default max file size of 2gb.

--- a/s3sign/static/s3sign/js/s3upload.js
+++ b/s3sign/static/s3sign/js/s3upload.js
@@ -40,13 +40,22 @@
 
         S3Upload.prototype.handleFileSelect = function(file_element) {
             var f, files, _i, _len, _results;
-            this.onProgress(0, 'Upload started.');
+
             files = file_element.files;
+
+            if (files.length === 0) {
+                return;
+            }
+
             _results = [];
+
+            this.onProgress(0, 'Upload started.');
+
             for (_i = 0, _len = files.length; _i < _len; _i++) {
                 f = files[_i];
                 _results.push(this.uploadFile(f));
             }
+
             return _results;
         };
 


### PR DESCRIPTION
This fixes a bug where canceling out of the file select dialog displays
the upload progress frozen at 0.