### PR TITLE
Respect the SignS3View's acl configuration - INFRA-2206

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.3.3
+==================
+* Fixed bug where `acl` attribute was not working, preventing the
+  ability to upload objects with `public-read` access.
+
 0.3.2 (2022-04-01)
 ==================
 * Don't call onProgress event handler if file list is empty.

--- a/README.md
+++ b/README.md
@@ -96,9 +96,14 @@ your page with:
 
 Your form would then somewhere have a bit like:
 
-    <p id="status"><strong>Please select a file</strong></p>
-    <input type="file" id="file" onchange="s3_upload();"/>
-    <input type="hidden" name="s3_url" id="uploaded-url" />
+    <form method="post">
+        <p id="status">
+            <strong>Please select a file</strong>
+        </p>
+
+        <input type="hidden" name="s3_url" id="uploaded-url" />
+        <input type="file" id="file" onchange="s3_upload();"/>
+    </form>
 
 And
 


### PR DESCRIPTION
The `acl` attribute wasn't being used. We need to set this in the presigned_post when we want the upload to have `public-read` access.