### PR TITLE
Revert "Update boto3[crt] requirement from <1.27.0,>=1.13.0 to >=1.13.0,<1.28.0"

### DIFF
--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -16,6 +16,5 @@ python-dateutil==2.8.2
 urllib3==1.26.15
 jmespath==1.0.1
 s3transfer==0.6.1
-
 botocore>=1.16.0,<1.31.0
-boto3[crt]>=1.13.0,<1.28.0
+boto3[crt]>=1.13.0,<1.27.0

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -16,5 +16,5 @@ python-dateutil==2.8.2
 urllib3==1.26.15
 jmespath==1.0.1
 s3transfer==0.6.1
-botocore>=1.16.0,<1.31.0
+botocore>=1.16.0,<1.30.0
 boto3[crt]>=1.13.0,<1.27.0


### PR DESCRIPTION
Reverts ccnmtl/django-s3sign#107