### PR TITLE
Github Actions: explicitly run flake8 & test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,5 +14,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Build and Test
-        run: make
+      - name: Run flake8
+        run: make flake8
+      - name: Run Tests
+        run: make test


### PR DESCRIPTION
Just running `make` is sort of unclear, as that will depend on how the Makefile is configured. I'm changing this to explicitly run flake8, and then the unit tests.