### PR TITLE
S3Upload.file_dom_selector: allow for any DOM selector

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.4.0
+==================
+* Adjust S3Upload.file_dom_selector to allow for any DOM selector
+  rather than just an ID.
+
 0.3.3 (2023-03-03)
 ==================
 * Fixed bug where `acl` attribute was not working, preventing the

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ And
 <script>
 function s3_upload() {
     var s3upload = new S3Upload({
-        file_dom_selector: 'file',
+        file_dom_selector: '#file',
         s3_sign_put_url: '/sign_s3/', // change this if you route differently
         s3_object_name: $('#file')[0].value,
 

--- a/s3sign/static/s3sign/js/s3upload.js
+++ b/s3sign/static/s3sign/js/s3upload.js
@@ -6,7 +6,7 @@
 
         S3Upload.prototype.s3_sign_put_url = '/signS3put';
 
-        S3Upload.prototype.file_dom_selector = 'file_upload';
+        S3Upload.prototype.file_dom_selector = '#file_upload';
 
         S3Upload.prototype.x_amz_acl = 'public-read';
 
@@ -28,7 +28,8 @@
             for (option in options) {
                 this[option] = options[option];
             }
-            this.handleFileSelect(document.getElementById(this.file_dom_selector));
+            this.handleFileSelect(
+                document.querySelector(this.file_dom_selector));
         }
 
         S3Upload.prototype.getXMLError = function(xmlDoc) {


### PR DESCRIPTION
Currently this code requires the selector to be the element's ID. This is unnecessary, and often it's more convenient to pass in the input selector via its `name` attribute.