### PR TITLE
S3SignView: cleanup method signatures and use tz-aware datetime

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@
 ==================
 * Refactored upload logic out of view code
 * Added .avif image format.
+* Clean up SignS3View method signatures
+* Use timezone-aware datetime object in SignS3View
 
 0.4.1 (2025-01-10)
 ==================

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Methods you can override:
 * `get_bucket(self)`
 * `get_mimetype(self, request)`
 * `extension_from_mimetype(self, mime_type)`
-* `now(self)` # useful for unit tests
-* `now_time(self)` # useful for unit tests
-* `basename(self)`
+* `now()` # useful for unit tests
+* `now_time()` # useful for unit tests
+* `basename()`
 * `get_object_name(self, extension)`
 
 Most of those should be clear. Read the source if in doubt.

--- a/s3sign/tests/test_views.py
+++ b/s3sign/tests/test_views.py
@@ -20,13 +20,16 @@ class PinnedView(SignS3View):
     def get_bucket(self):
         return "bucket"
 
-    def now(self):
+    @staticmethod
+    def now():
         return datetime(year=2016, month=1, day=1)
 
-    def now_time(self):
+    @staticmethod
+    def now_time():
         return 0
 
-    def basename(self, request):
+    @staticmethod
+    def basename():
         return "f495f780-5fd3-45d3-9483-becc7ebff922"
 
 
@@ -45,7 +48,7 @@ class TestView(TestCase):
 
     def test_basename(self):
         v = SignS3View()
-        self.assertIsNotNone(v.basename(None))
+        self.assertIsNotNone(v.basename())
 
     def test_extension_from_mimetype(self):
         v = SignS3View()

--- a/s3sign/views.py
+++ b/s3sign/views.py
@@ -6,11 +6,10 @@ import uuid
 
 import boto3
 
-from datetime import datetime
-
 from django.conf import settings
 from django.http import HttpResponse
 from django.views.generic import View
+from django.utils import timezone
 
 from s3sign.utils import s3_config, upload_file
 
@@ -59,34 +58,34 @@ class SignS3View(View):
         )
         return super().dispatch(request, *args, **kwargs)
 
-    def get_name_field(self):
+    def get_name_field(self) -> str:
         return self.name_field
 
-    def get_type_field(self):
+    def get_type_field(self) -> str:
         return self.type_field
 
     def get_expiration_time(self):
         return self.expiration_time
 
-    def get_mime_type_extensions(self):
+    def get_mime_type_extensions(self) -> list:
         return self.mime_type_extensions
 
-    def get_default_extension(self):
+    def get_default_extension(self) -> str:
         return self.default_extension
 
-    def get_root(self):
+    def get_root(self) -> str:
         return self.root
 
-    def get_path_string(self):
+    def get_path_string(self) -> str:
         return self.path_string
 
-    def get_aws_access_key(self):
+    def get_aws_access_key(self) -> str:
         return settings.AWS_ACCESS_KEY
 
-    def get_aws_secret_key(self):
+    def get_aws_secret_key(self) -> str:
         return settings.AWS_SECRET_KEY
 
-    def get_bucket(self):
+    def get_bucket(self) -> str:
         return settings.AWS_UPLOAD_BUCKET
 
     def get_mimetype(self, request):
@@ -98,13 +97,16 @@ class SignS3View(View):
                 return ext
         return self.get_default_extension()
 
-    def now(self):
-        return datetime.now()
+    @staticmethod
+    def now():
+        return timezone.now()
 
-    def now_time(self):
+    @staticmethod
+    def now_time():
         return time.time()
 
-    def basename(self, request):
+    @staticmethod
+    def basename():
         return str(uuid.uuid4())
 
     def extension(self, request):
@@ -112,7 +114,7 @@ class SignS3View(View):
 
     def get_object_name(self, request):
         now = self.now()
-        basename = self.basename(request)
+        basename = self.basename()
         extension = self.extension(request)
         return self.get_path_string().format(
             now=now, basename=basename, extension=extension,


### PR DESCRIPTION
A number of these methods are actually static methods, and don't rely on the instance object. I'm cleaning up some of the code here, and also updating the datetime.now() to call timezone.now(), as recommended by Django and which we use everywhere else.