### PR TITLE
Update upload_file return type to dict

### DIFF
--- a/s3sign/utils.py
+++ b/s3sign/utils.py
@@ -106,7 +106,7 @@ def create_presigned_post(s3_client, bucket_name, object_name,
 def upload_file(
         s3_client, bucket, mime_type, object_name,
         max_file_size, acl, expiration_time, private
-) -> object:
+) -> dict:
     S3_BUCKET = bucket
     mime_type = mime_type
     object_name = object_name


### PR DESCRIPTION
I just realized `object` is a bit general here: this includes like, any type in python. We expect this method to return a data dictionary - what i'd call an "object" in JavaScript, but python calls a dictionary, so I think we can change this to `dict`.