### PR TITLE
Don't export class in s3upload.js

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.6.4
+==================
+* Don't use class export in s3upload.js
+
 0.6.3 (2026-02-20)
 ==================
 * Use default extension when no mime type is present

--- a/s3sign/static/s3sign/js/s3upload.js
+++ b/s3sign/static/s3sign/js/s3upload.js
@@ -1,4 +1,4 @@
-export default class S3Upload {
+class S3Upload {
     constructor(options={}) {
         this.s3_object_name = 'default_name';
         this.s3_sign_put_url = '/signS3put';


### PR DESCRIPTION
We don't generally use this as a module - using export here breaks applications using this in the traditional way.